### PR TITLE
JsonNode도 받을 수 있도록 generateRequestBody 수정. README.md 파일 추가.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Salesforce File Upload
+Salesforce 파일 업로드 프로그램.
+
+* 언어 (Language): Java 17
+* 프레임워크 (Framework):
+    * Spring Framework 6.2.6
+    * Spring Boot 3.4.5
+    * Spring Security 6.2.1
+* 템플릿 엔진 (View Template): Thymeleaf 3.1.2
+* 웹 서버 (WAS): Apache Tomcat 10.1.17
+* 데이터베이스 (Database): MariaDB 3.2.0
+* 빌드 도구 (Build Tool): Gradle 8.4
+* Salesforce API
+    * Connect REST API
+        * connect/files/users/me
+        * connect/batch
+    * sObjects REST API
+        * sobjects/ContentDocumentLink

--- a/src/main/java/com/sfdcupload/common/SalesforceFileUpload.java
+++ b/src/main/java/com/sfdcupload/common/SalesforceFileUpload.java
@@ -120,8 +120,8 @@ public class SalesforceFileUpload {
         }
     }
 
-    private RequestBody generateRequestBody(Map<String, String> mapContent, ObjectMapper mapper) throws JsonProcessingException {
-        String jsonBody = mapper.writeValueAsString(mapContent);
+    private RequestBody generateRequestBody(Object object, ObjectMapper mapper) throws JsonProcessingException {
+        String jsonBody = mapper.writeValueAsString(object);
         return RequestBody.create(jsonBody, MediaType.parse("application/json"));
     }
 
@@ -131,8 +131,7 @@ public class SalesforceFileUpload {
         // 50MB 까지. 근데 base64로 인코딩 해야함
         // 인코딩 시 용량이 33% 늘어남. 대략 원본 용량 35MB 까지 가능
         // 제한사항도 동일
-        // batch로 보냉 수 있...나?
-
+        // batch로 보낼 수 있...나?
 
         OkHttpClient client = new OkHttpClient();
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
generateRequestBody에 Map<String, String>뿐만 아니라 JsonNode도 받을 수 있도록 generateRequestBody 수정. 
매개변수로 Object 받음. 어짜피 Jackson이 JSON으로 만들어줌.
README.md 파일도 추가함.